### PR TITLE
fix: call getPersistentAttributes first time

### DIFF
--- a/packages/core/libs/attributeManager.ts
+++ b/packages/core/libs/attributeManager.ts
@@ -21,7 +21,7 @@ export const getSessionAttribute = (handlerInput: HandlerInput, attributeName: s
 export const getPersistentAttributes = async <Attributes = {[key: string]: any}>(handlerInput: HandlerInput, defaultAttributes: Attributes): Promise<Attributes> => {
     try {
         const data = await handlerInput.attributesManager.getPersistentAttributes()
-        if (!data) return defaultAttributes
+        if (!data || Object.keys(data).length === 0) return defaultAttributes
         return data as Attributes
     } catch (e) {
         return defaultAttributes


### PR DESCRIPTION
Fix the problem that `defaultAttributes` is not returned when calling `getPersistentAttributes` for the first time.

For first time, return value of `handlerInput.attributesManager.getPersistentAttributes()` is `{}`, so condition was added.