### PR TITLE
fix: skip AudioPlayerRequest in SetLaunchCountInterceptor

### DIFF
--- a/packages/core/libs/requestHandler.ts
+++ b/packages/core/libs/requestHandler.ts
@@ -20,3 +20,7 @@ export const mergeHandler = (cloneTarget: RequestHandler, mergeObject: MergeObje
 export const isSkillEvent = (requestEnvelope: RequestEnvelope): boolean => {
     return /^AlexaSkillEvent/.test(requestEnvelope.request.type)
 }
+
+export const isAudioPlayerRequest = (requestEnvelope: RequestEnvelope): boolean => {
+    return /^AudioPlayer/.test(requestEnvelope.request.type)
+}

--- a/packages/handlers/libs/requestInterceptors/LaunchCount.ts
+++ b/packages/handlers/libs/requestInterceptors/LaunchCount.ts
@@ -2,6 +2,7 @@ import { HandlerInput, isNewSession } from 'ask-sdk-core'
 import { RequestInterceptor } from 'ask-sdk-runtime'
 import {
     isSkillEvent,
+    isAudioPlayerRequest,
     getPersistentAttributes,
     updateSessionAttributes
 } from 'ask-utils'
@@ -9,7 +10,7 @@ import moment from 'moment'
 
 export const SetLaunchCountInterceptor: RequestInterceptor<HandlerInput> = {
     async process (input: HandlerInput) {
-        if (isSkillEvent(input.requestEnvelope)) return
+        if (isSkillEvent(input.requestEnvelope) || isAudioPlayerRequest(input.requestEnvelope)) return
         if (!isNewSession(input.requestEnvelope)) return
         const defaultState = {
             launchCount: 0,


### PR DESCRIPTION
In AudioPlayerSkill, I got the error `The provided request doesn't contain a session`.


According to the docs, there is no session in AudioPlayerRequest, so I added a handle for it.

---

> Important: These requests do not include the session object, since they are not sent in the context of a skill session. Use the context object to get details such as the applicationId and userId.

https://developer.amazon.com/en-US/docs/alexa/custom-skills/audioplayer-interface-reference.html#requests